### PR TITLE
normalize the scheme's name before comparing it with the input

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -18,6 +18,7 @@ workflows:
             go get -u -v github.com/bitrise-io/go-utils/command
             go get -u -v github.com/bitrise-io/go-utils/fileutil
             go get -u -v github.com/bitrise-io/go-utils/pathutil
+            go get -u -v golang.org/x/text/unicode/norm
     - go-list:
     - golint:
     - errcheck:

--- a/xcodeproj/xcodeproj.go
+++ b/xcodeproj/xcodeproj.go
@@ -12,6 +12,7 @@ import (
 	"github.com/bitrise-tools/xcode-project/serialized"
 	"github.com/bitrise-tools/xcode-project/xcodebuild"
 	"github.com/bitrise-tools/xcode-project/xcscheme"
+	"golang.org/x/text/unicode/norm"
 	"howett.net/plist"
 )
 
@@ -189,8 +190,10 @@ func (p XcodeProj) Scheme(name string) (xcscheme.Scheme, bool) {
 		return xcscheme.Scheme{}, false
 	}
 
+	normName := norm.NFC.String(name)
 	for _, scheme := range schemes {
-		if scheme.Name == name {
+		normSchemeName := norm.NFC.String(scheme.Name)
+		if normSchemeName == normName {
 			return scheme, true
 		}
 	}

--- a/xcodeproj/xcodeproj.go
+++ b/xcodeproj/xcodeproj.go
@@ -192,8 +192,7 @@ func (p XcodeProj) Scheme(name string) (xcscheme.Scheme, bool) {
 
 	normName := norm.NFC.String(name)
 	for _, scheme := range schemes {
-		normSchemeName := norm.NFC.String(scheme.Name)
-		if normSchemeName == normName {
+		if norm.NFC.String(scheme.Name) == normName {
 			return scheme, true
 		}
 	}

--- a/xcodeproj/xcodeproj_test.go
+++ b/xcodeproj/xcodeproj_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/bitrise-tools/xcode-project/serialized"
 	"github.com/bitrise-tools/xcode-project/testhelper"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/text/unicode/norm"
 )
 
 func TestResolve(t *testing.T) {
@@ -173,6 +174,22 @@ func TestScheme(t *testing.T) {
 		require.False(t, ok)
 		require.Equal(t, "", scheme.Name)
 	}
+
+	{
+		// Gdańsk represented in High Sierra
+		b := []byte{71, 100, 97, 197, 132, 115, 107}
+		scheme, ok := project.Scheme(string(b))
+		require.True(t, ok)
+		require.Equal(t, norm.NFC.String(string(b)), norm.NFC.String(scheme.Name))
+	}
+
+	{
+		// Gdańsk represented in Mojave
+		b := []byte{71, 100, 97, 110, 204, 129, 115, 107}
+		scheme, ok := project.Scheme(string(b))
+		require.True(t, ok)
+		require.Equal(t, norm.NFC.String(string(b)), norm.NFC.String(scheme.Name))
+	}
 }
 
 func TestSchemes(t *testing.T) {
@@ -182,10 +199,17 @@ func TestSchemes(t *testing.T) {
 
 	schemes, err := project.Schemes()
 	require.NoError(t, err)
-	require.Equal(t, 2, len(schemes))
+	require.Equal(t, 3, len(schemes))
 
-	require.Equal(t, "ProjectScheme", schemes[0].Name)
-	require.Equal(t, "ProjectTodayExtensionScheme", schemes[1].Name)
+	// Gdańsk represented in High Sierra
+	b := []byte{71, 100, 97, 197, 132, 115, 107}
+	require.Equal(t, norm.NFC.String(string(b)), norm.NFC.String(schemes[0].Name))
+	require.Equal(t, "ProjectScheme", schemes[1].Name)
+
+	// Gdańsk represented in Mojave
+	b = []byte{71, 100, 97, 110, 204, 129, 115, 107}
+	require.Equal(t, norm.NFC.String(string(b)), norm.NFC.String(schemes[0].Name))
+	require.Equal(t, "ProjectScheme", schemes[1].Name)
 }
 
 func TestOpenXcodeproj(t *testing.T) {

--- a/xcworkspace/xcworkspace.go
+++ b/xcworkspace/xcworkspace.go
@@ -12,6 +12,7 @@ import (
 	"github.com/bitrise-tools/xcode-project/xcodebuild"
 	"github.com/bitrise-tools/xcode-project/xcodeproj"
 	"github.com/bitrise-tools/xcode-project/xcscheme"
+	"golang.org/x/text/unicode/norm"
 )
 
 // Workspace represents an Xcode workspace
@@ -30,9 +31,11 @@ func (w Workspace) Scheme(name string) (xcscheme.Scheme, string, error) {
 		return xcscheme.Scheme{}, "", err
 	}
 
+	normName := norm.NFC.String(name)
 	for container, schemes := range schemesByContainer {
 		for _, scheme := range schemes {
-			if scheme.Name == name {
+			normSchemeName := norm.NFC.String(scheme.Name)
+			if normSchemeName == normName {
 				return scheme, container, nil
 			}
 		}

--- a/xcworkspace/xcworkspace.go
+++ b/xcworkspace/xcworkspace.go
@@ -34,8 +34,7 @@ func (w Workspace) Scheme(name string) (xcscheme.Scheme, string, error) {
 	normName := norm.NFC.String(name)
 	for container, schemes := range schemesByContainer {
 		for _, scheme := range schemes {
-			normSchemeName := norm.NFC.String(scheme.Name)
-			if normSchemeName == normName {
+			if norm.NFC.String(scheme.Name) == normName {
 				return scheme, container, nil
 			}
 		}

--- a/xcworkspace/xcworkspace_test.go
+++ b/xcworkspace/xcworkspace_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/bitrise-tools/xcode-project/testhelper"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/text/unicode/norm"
 )
 
 func TestScheme(t *testing.T) {
@@ -26,6 +27,24 @@ func TestScheme(t *testing.T) {
 		require.Equal(t, "", container)
 		require.Equal(t, "", scheme.Name)
 	}
+
+	{
+		// Gdańsk represented in High Sierra
+		b := []byte{71, 100, 97, 197, 132, 115, 107}
+		scheme, container, err := workspace.Scheme(string(b))
+		require.NoError(t, err)
+		require.Equal(t, filepath.Join(dir, "XcodeProj.xcodeproj"), container)
+		require.Equal(t, norm.NFC.String(string(b)), norm.NFC.String(scheme.Name))
+	}
+
+	{
+		// Gdańsk represented in Mojave
+		b := []byte{71, 100, 97, 110, 204, 129, 115, 107}
+		scheme, container, err := workspace.Scheme(string(b))
+		require.NoError(t, err)
+		require.Equal(t, filepath.Join(dir, "XcodeProj.xcodeproj"), container)
+		require.Equal(t, norm.NFC.String(string(b)), norm.NFC.String(scheme.Name))
+	}
 }
 
 func TestSchemes(t *testing.T) {
@@ -45,9 +64,17 @@ func TestSchemes(t *testing.T) {
 
 	{
 		schemes := schemesByContainer[filepath.Join(dir, "XcodeProj.xcodeproj")]
-		require.Equal(t, 2, len(schemes))
-		require.Equal(t, "ProjectScheme", schemes[0].Name)
-		require.Equal(t, "ProjectTodayExtensionScheme", schemes[1].Name)
+		require.Equal(t, 3, len(schemes))
+
+		// Gdańsk represented in High Sierra
+		b := []byte{71, 100, 97, 197, 132, 115, 107}
+		require.Equal(t, norm.NFC.String(string(b)), norm.NFC.String(schemes[0].Name))
+		require.Equal(t, "ProjectScheme", schemes[1].Name)
+
+		// Gdańsk represented in Mojave
+		b = []byte{71, 100, 97, 110, 204, 129, 115, 107}
+		require.Equal(t, norm.NFC.String(string(b)), norm.NFC.String(schemes[0].Name))
+		require.Equal(t, "ProjectScheme", schemes[1].Name)
 	}
 
 	{


### PR DESCRIPTION
This will fix the issue which was caused by the case, that different OSX version represents some characters differently.
E.g: `ń`